### PR TITLE
perf: iterate over CardPlay without allocation

### DIFF
--- a/strategies/src/input_strategy.rs
+++ b/strategies/src/input_strategy.rs
@@ -214,23 +214,21 @@ fn play_action_from_captures(caps: &Captures, actions: &[Action]) -> Result<Acti
     let &card_play = actions
         .iter()
         .find_map(|act| {
-            if let Action::PlayCards { card_play } = act {
-                // correct # of cards?
-                if card_play.size() != cards.len() {
-                    return None;
-                }
-                // rank matches and all suits are accounted for?
-                let cp_cards = card_play.to_vec();
-                let suits: Vec<Suit> = cards.iter().filter_map(|c| c.1).collect();
-                if card_play.rank() == rank
-                    && suits
-                        .iter()
-                        .all(|suit| cp_cards.iter().any(|c| c.suit() == *suit))
-                {
-                    Some(card_play)
-                } else {
-                    None
-                }
+            let Action::PlayCards { card_play } = act else {
+                return None;
+            };
+            // correct # of cards?
+            if card_play.size() != cards.len() {
+                return None;
+            }
+            // rank matches and all suits are accounted for?
+            let suits: Vec<Suit> = cards.iter().filter_map(|c| c.1).collect();
+            if card_play.rank() == rank
+                && suits
+                    .iter()
+                    .all(|suit| card_play.cards().any(|c| c.suit() == *suit))
+            {
+                Some(card_play)
             } else {
                 None
             }

--- a/types/src/action.rs
+++ b/types/src/action.rs
@@ -18,7 +18,8 @@ impl Display for Action {
             Action::SendCard { card, .. } => format!("Send {card}"),
             Action::Pass => "Pass".to_string(),
             Action::PlayCards { card_play } => {
-                format!("Play {}", card_play.to_vec().iter().join(","))
+                let cards = card_play.cards().map(|card| format!("{card}")).join(",");
+                format!("Play {cards}")
             }
         };
         write!(f, "{}", string)

--- a/types/src/game_state.rs
+++ b/types/src/game_state.rs
@@ -117,7 +117,9 @@ impl GameState {
         if is_first_cardplay {
             let (_, starting_card) = self.starting_player_and_card();
             actions.retain(|action| match action {
-                Action::PlayCards { card_play } => card_play.to_vec().contains(&starting_card),
+                Action::PlayCards { card_play } => {
+                    card_play.cards().any(|card| card == starting_card)
+                }
                 _ => false,
             });
         }
@@ -138,8 +140,8 @@ impl GameState {
             }
             Action::Pass => {}
             Action::PlayCards { card_play } => {
-                for card in &card_play.to_vec() {
-                    let removed = player.state.current_hand.remove_card(card);
+                for card in card_play.cards() {
+                    let removed = player.state.current_hand.remove_card(&card);
                     assert!(
                         removed,
                         "Attempted to play a card {:?} that wasn't in the hand!",


### PR DESCRIPTION
## Summary
- add `CardPlay::cards()` iterator + `CardPlayCards`
- swap display, validation, and gameplay logic to iterate instead of cloning vecs
- left `to_vec()` delegating to the iterator for compatibility
- verified with `cargo test -p types` and `cargo test -p strategies`
