### PR TITLE
chore: clarify Action conversion

### DIFF
--- a/types/src/action.rs
+++ b/types/src/action.rs
@@ -26,8 +26,10 @@ impl Display for Action {
 }
 
 impl From<&CardPlay> for Action {
-    fn from(&card_play: &CardPlay) -> Self {
-        Action::PlayCards { card_play }
+    fn from(card_play: &CardPlay) -> Self {
+        Action::PlayCards {
+            card_play: *card_play,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid binding pattern syntax in `impl From<&CardPlay>`
- explicitly copy the card play inside the conversion
- verified with `cargo test -p types`
